### PR TITLE
Update cci to 2.2.3

### DIFF
--- a/cumulusci.rb
+++ b/cumulusci.rb
@@ -2,10 +2,10 @@ class Cumulusci < Formula
   include Language::Python::Virtualenv
 
   desc "Python framework for building portable automation for Salesforce projects"
+  head "https://github.com/SFDO-Tooling/CumulusCI.git"
   homepage "https://github.com/SFDO-Tooling/CumulusCI"
   url "https://files.pythonhosted.org/packages/4f/90/028caa2f5ed78a03ce7262e6817d94afbf6e25cd04452b10124f724bd5eb/cumulusci-2.2.3.tar.gz"
   sha256 "11f423edab27a45f2e8652006d74ceb28e4e6d5f81efd6c7e54f7d3e269d8254"
-  head "https://github.com/SFDO-Tooling/CumulusCI.git"
 
   depends_on "python3"
 
@@ -39,11 +39,6 @@ class Cumulusci < Formula
     sha256 "b869a2dda3fa88154b9dd850e27828d8755bfab5a838a1c97fbc850c6e377c36"
   end
 
-  resource "contextlib2" do
-    url "https://files.pythonhosted.org/packages/6e/db/41233498c210b03ab8b072c8ee49b1cd63b3b0c76f8ea0a0e5d02df06898/contextlib2-0.5.5.tar.gz"
-    sha256 "509f9419ee91cdd00ba34443217d5ca51f5a364a404e1dce9e8979cea969ca48"
-  end
-
   resource "cryptography" do
     url "https://files.pythonhosted.org/packages/f3/39/d3904df7c56f8654691c4ae1bdb270c1c9220d6da79bd3b1fbad91afd0e1/cryptography-2.4.2.tar.gz"
     sha256 "05a6052c6a9f17ff78ba78f8e6eb1d777d25db3b763343a1ae89a7a8670386dd"
@@ -52,11 +47,6 @@ class Cumulusci < Formula
   resource "docutils" do
     url "https://files.pythonhosted.org/packages/84/f4/5771e41fdf52aabebbadecc9381d11dea0fa34e4759b4071244fa094804c/docutils-0.14.tar.gz"
     sha256 "51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274"
-  end
-
-  resource "enum34" do
-    url "https://files.pythonhosted.org/packages/bf/3e/31d502c25302814a7c2f1d3959d2a3b3f78e509002ba91aea64993936876/enum34-1.1.6.tar.gz"
-    sha256 "8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
   end
 
   resource "future" do
@@ -79,11 +69,6 @@ class Cumulusci < Formula
     sha256 "684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
   end
 
-  resource "ipaddress" do
-    url "https://files.pythonhosted.org/packages/97/8d/77b8cedcfbf93676148518036c6b1ce7f8e14bf07e95d7fd4ddcb8cc052f/ipaddress-1.0.22.tar.gz"
-    sha256 "b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c"
-  end
-
   resource "Jinja2" do
     url "https://files.pythonhosted.org/packages/56/e6/332789f295cf22308386cf5bbd1f4e00ed11484299c5d7383378cf48ba47/Jinja2-2.10.tar.gz"
     sha256 "f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
@@ -102,11 +87,6 @@ class Cumulusci < Formula
   resource "MarkupSafe" do
     url "https://files.pythonhosted.org/packages/ac/7e/1b4c2e05809a4414ebce0892fe1e32c14ace86ca7d50c70f00979ca9b3a3/MarkupSafe-1.1.0.tar.gz"
     sha256 "4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3"
-  end
-
-  resource "monotonic" do
-    url "https://files.pythonhosted.org/packages/19/c1/27f722aaaaf98786a1b338b78cf60960d9fe4849825b071f4e300da29589/monotonic-1.5.tar.gz"
-    sha256 "23953d55076df038541e648a53676fb24980f7a1be290cdda21300b3bc21dfb0"
   end
 
   resource "plaintable" do

--- a/cumulusci.rb
+++ b/cumulusci.rb
@@ -3,8 +3,8 @@ class Cumulusci < Formula
 
   desc "Python framework for building portable automation for Salesforce projects"
   homepage "https://github.com/SFDO-Tooling/CumulusCI"
-  url "https://files.pythonhosted.org/packages/39/7c/0cdda1ffd69e4421665aa7e6e32d447ead4602842499a9d80e2e579e4d3d/cumulusci-2.2.2.tar.gz"
-  sha256 "1fef3505f49a0543662c3ff9d4634b3d6c03cc54c58a9771a572d1109eb16181"
+  url "https://files.pythonhosted.org/packages/4f/90/028caa2f5ed78a03ce7262e6817d94afbf6e25cd04452b10124f724bd5eb/cumulusci-2.2.3.tar.gz"
+  sha256 "11f423edab27a45f2e8652006d74ceb28e4e6d5f81efd6c7e54f7d3e269d8254"
   head "https://github.com/SFDO-Tooling/CumulusCI.git"
 
   depends_on "python3"
@@ -15,8 +15,8 @@ class Cumulusci < Formula
   end
 
   resource "certifi" do
-    url "https://files.pythonhosted.org/packages/41/b6/4f0cefba47656583217acd6cd797bc2db1fede0d53090fdc28ad2c8e0716/certifi-2018.10.15.tar.gz"
-    sha256 "6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a"
+    url "https://files.pythonhosted.org/packages/55/54/3ce77783acba5979ce16674fc98b1920d00b01d337cfaaf5db22543505ed/certifi-2018.11.29.tar.gz"
+    sha256 "47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7"
   end
 
   resource "cffi" do
@@ -39,6 +39,11 @@ class Cumulusci < Formula
     sha256 "b869a2dda3fa88154b9dd850e27828d8755bfab5a838a1c97fbc850c6e377c36"
   end
 
+  resource "contextlib2" do
+    url "https://files.pythonhosted.org/packages/6e/db/41233498c210b03ab8b072c8ee49b1cd63b3b0c76f8ea0a0e5d02df06898/contextlib2-0.5.5.tar.gz"
+    sha256 "509f9419ee91cdd00ba34443217d5ca51f5a364a404e1dce9e8979cea969ca48"
+  end
+
   resource "cryptography" do
     url "https://files.pythonhosted.org/packages/f3/39/d3904df7c56f8654691c4ae1bdb270c1c9220d6da79bd3b1fbad91afd0e1/cryptography-2.4.2.tar.gz"
     sha256 "05a6052c6a9f17ff78ba78f8e6eb1d777d25db3b763343a1ae89a7a8670386dd"
@@ -47,6 +52,11 @@ class Cumulusci < Formula
   resource "docutils" do
     url "https://files.pythonhosted.org/packages/84/f4/5771e41fdf52aabebbadecc9381d11dea0fa34e4759b4071244fa094804c/docutils-0.14.tar.gz"
     sha256 "51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274"
+  end
+
+  resource "enum34" do
+    url "https://files.pythonhosted.org/packages/bf/3e/31d502c25302814a7c2f1d3959d2a3b3f78e509002ba91aea64993936876/enum34-1.1.6.tar.gz"
+    sha256 "8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
   end
 
   resource "future" do
@@ -69,6 +79,11 @@ class Cumulusci < Formula
     sha256 "684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
   end
 
+  resource "ipaddress" do
+    url "https://files.pythonhosted.org/packages/97/8d/77b8cedcfbf93676148518036c6b1ce7f8e14bf07e95d7fd4ddcb8cc052f/ipaddress-1.0.22.tar.gz"
+    sha256 "b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c"
+  end
+
   resource "Jinja2" do
     url "https://files.pythonhosted.org/packages/56/e6/332789f295cf22308386cf5bbd1f4e00ed11484299c5d7383378cf48ba47/Jinja2-2.10.tar.gz"
     sha256 "f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
@@ -87,6 +102,11 @@ class Cumulusci < Formula
   resource "MarkupSafe" do
     url "https://files.pythonhosted.org/packages/ac/7e/1b4c2e05809a4414ebce0892fe1e32c14ace86ca7d50c70f00979ca9b3a3/MarkupSafe-1.1.0.tar.gz"
     sha256 "4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3"
+  end
+
+  resource "monotonic" do
+    url "https://files.pythonhosted.org/packages/19/c1/27f722aaaaf98786a1b338b78cf60960d9fe4849825b071f4e300da29589/monotonic-1.5.tar.gz"
+    sha256 "23953d55076df038541e648a53676fb24980f7a1be290cdda21300b3bc21dfb0"
   end
 
   resource "plaintable" do


### PR DESCRIPTION
- [Update CCI](#sec-1-1)
    - [Update homebrew formula](#sec-1-2)
    - [Manually update generated format](#sec-1-3)

# Creating a new release<a id="sec-1"></a>

Here we demonstrate the steps to update and release a new version of cumulusci on hombrew.

```shell
pwd
```

    /Users/jestevez/projects/rel/homebrew-sfdo

```shell
pyenv version
```

    cci-brew (set by /Users/jestevez/projects/rel/homebrew-sfdo/.python-version)

## Update CCI<a id="sec-1-1"></a>

```shell
pip install --upgrade cumulusci
```

    4072f96eb2b09ca0895e8e8f793ef8cc

    Collecting cumulusci
      Downloading https://files.pythonhosted.org/packages/85/e1/d78fad95d4ddb87293196266e1e39960915883374c14024948dee4b2a89b/cumulusci-2.2.3-py2.py3-none-any.whl (291kB)
    Collecting xmltodict==0.11.0 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/42/a9/7e99652c6bc619d19d58cdd8c47560730eb5825d43a7e25db2e1d776ceb7/xmltodict-0.11.0-py2.py3-none-any.whl
    Collecting robotframework==3.0.4 (from cumulusci)
    Collecting lxml==4.2.5 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/df/31/3e2754bc977738bf7ee1303b99f07599b455cd4a7f16f5be63704c446303/lxml-4.2.5-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
    Collecting cffi==1.11.5 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/7e/4a/b647e46faaa2dcfb16069b6aad2d8509982fd63710a325b8ad7db80f18be/cffi-1.11.5-cp27-cp27m-macosx_10_6_intel.whl
    Collecting github3.py==1.2.0 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/00/cb/ee49ebb79f900b6fe37f53e128ad63d0d0d7bd72caee2a47bd813f046bbc/github3.py-1.2.0-py2.py3-none-any.whl
    Collecting python-dateutil==2.7.5 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/74/68/d87d9b36af36f44254a8d512cbfc48369103a3b9e474be9bdfe536abfc45/python_dateutil-2.7.5-py2.py3-none-any.whl
    Requirement already satisfied, skipping upgrade: six==1.11.0 in /usr/local/lib/python2.7/site-packages (from cumulusci) (1.11.0)
    Collecting robotframework-seleniumlibrary==3.2.0 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/74/e9/19f4f96e1f35ed34e5f9d06d8285f981d2b8c5e7efa23d5c201c4650d732/robotframework_seleniumlibrary-3.2.0-py2.py3-none-any.whl
    Collecting click==7.0 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/fa/37/45185cb5abbc30d7257104c434fe0b07e5a195a6847506c074527aa599ec/Click-7.0-py2.py3-none-any.whl
    Collecting certifi==2018.11.29 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/9f/e0/accfc1b56b57e9750eba272e24c4dddeac86852c2bebd1236674d7887e8a/certifi-2018.11.29-py2.py3-none-any.whl
    Collecting idna==2.7 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/4b/2a/0276479a4b3caeb8a8c1af2f8e4355746a97fab05a372e4a2c6a6b876165/idna-2.7-py2.py3-none-any.whl
    Collecting asn1crypto==0.24.0 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/ea/cd/35485615f45f30a510576f1a56d1e0a7ad7bd8ab5ed7cdc600ef7cd06222/asn1crypto-0.24.0-py2.py3-none-any.whl
    Collecting docutils==0.14 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/50/09/c53398e0005b11f7ffb27b7aa720c617aba53be4fb4f4f3f06b9b5c60f28/docutils-0.14-py2-none-any.whl
    Collecting sarge==0.1.5.post0 (from cumulusci)
    Collecting jwcrypto==0.6.0 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/f0/0d/00173a6aee1025e529b21c365182c8d06e78b1beb98d5633f841da6f122e/jwcrypto-0.6.0-py2.py3-none-any.whl
    Collecting pycparser==2.19 (from cumulusci)
    Collecting raven==6.9.0 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/11/3a/b3e46b279b8bdd9eb55857d0e95044cad31732c80f628bb75e1e9e881a32/raven-6.9.0-py2.py3-none-any.whl
    Collecting cryptography==2.4.2 (from cumulusci)
      Downloading https://files.pythonhosted.org/packages/76/69/3464878ad1211f1f842e89217d907645849c5bfe20e20c695a1d7e4a7c88/cryptography-2.4.2-cp27-cp27m-macosx_10_6_intel.whl (1.5MB)
    Collecting requests[security]==2.20.1 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/ff/17/5cbb026005115301a8fb2f9b0e3e8d32313142fe8b617070e7baad20554f/requests-2.20.1-py2.py3-none-any.whl
    Collecting selenium==3.141.0 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/80/d6/4294f0b4bce4de0abf13e17190289f9d0613b0a44e5dd6a7f5ca98459853/selenium-3.141.0-py2.py3-none-any.whl
    Collecting chardet==3.0.4 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/bc/a9/01ffebfb562e4274b6487b4bb1ddec7ca55ec7510b22e4c51f14098443b8/chardet-3.0.4-py2.py3-none-any.whl
    Collecting salesforce-bulk==2.1.0 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/2b/9f/48f6049b4eed650e1bbf55fa29f39b58fdb22cd4aa01d5637775067dbc63/salesforce_bulk-2.1.0-py2.py3-none-any.whl
    Collecting simple-salesforce==0.74.2 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/ad/59/c63fed8dcbfe91d398321d8d8f28c0a3660f861c8d5c57361af65ad13615/simple_salesforce-0.74.2-py2.py3-none-any.whl
    Collecting humanfriendly==4.17 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/79/1e/13d96248e3fcaa7777b61fa889feab44865c85e524bbd667acfa0d8b66e3/humanfriendly-4.17-py2.py3-none-any.whl
    Collecting urllib3==1.24.1 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/62/00/ee1d7de624db8ba7090d1226aebefab96a2c71cd5cfa7629d6ad3f61b79e/urllib3-1.24.1-py2.py3-none-any.whl
    Collecting rst2ansi==0.1.5 (from cumulusci)
    Collecting MarkupSafe==1.1.0 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/cd/52/927263d9cf66a12e05c5caef43ee203bd92355e9a321552d2b8c4aee5f1e/MarkupSafe-1.1.0-cp27-cp27m-macosx_10_6_intel.whl
    Collecting coloredlogs==10.0 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/08/0f/7877fc42fff0b9d70b6442df62d53b3868d3a6ad1b876bdb54335b30ff23/coloredlogs-10.0-py2.py3-none-any.whl
    Collecting uritemplate==3.0.0 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/f6/25/66a49231b44409d7f07cfcf2506a8b070ce3c99fc47cc256bea833f24791/uritemplate-3.0.0-py2-none-any.whl
    Collecting pytz==2018.7 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/f8/0e/2365ddc010afb3d79147f1dd544e5ee24bf4ece58ab99b16fbb465ce6dc0/pytz-2018.7-py2.py3-none-any.whl
    Collecting plaintable==0.1.1 (from cumulusci)
    Requirement already satisfied, skipping upgrade: PyYAML==3.13 in /usr/local/lib/python2.7/site-packages (from cumulusci) (3.13)
    Collecting unicodecsv==0.14.1 (from cumulusci)
    Collecting jinja2==2.10 (from cumulusci)
      Using cached https://files.pythonhosted.org/packages/7f/ff/ae64bacdfc95f27a016a7bed8e8686763ba4d277a78ca76f32659220a731/Jinja2-2.10-py2.py3-none-any.whl
    Collecting SQLAlchemy==1.2.14 (from cumulusci)
    Collecting future==0.17.1 (from cumulusci)
    Requirement already satisfied, skipping upgrade: contextlib2; python_version < "3.2" in /usr/local/lib/python2.7/site-packages (from raven==6.9.0->cumulusci) (0.5.5)
    Requirement already satisfied, skipping upgrade: enum34; python_version < "3" in /usr/local/lib/python2.7/site-packages (from cryptography==2.4.2->cumulusci) (1.1.6)
    Requirement already satisfied, skipping upgrade: ipaddress; python_version < "3" in /usr/local/lib/python2.7/site-packages (from cryptography==2.4.2->cumulusci) (1.0.22)
    Requirement already satisfied, skipping upgrade: pyOpenSSL>=0.14; extra == "security" in /usr/local/lib/python2.7/site-packages (from requests[security]==2.20.1->cumulusci) (18.0.0)
    Requirement already satisfied, skipping upgrade: monotonic; python_version == "2.6" or python_version == "2.7" or python_version == "3.0" or python_version == "3.1" or python_version == "3.2" in /usr/local/lib/python2.7/site-packages (from humanfriendly==4.17->cumulusci) (1.5)
    Installing collected packages: xmltodict, robotframework, lxml, pycparser, cffi, uritemplate, idna, asn1crypto, cryptography, jwcrypto, certifi, chardet, urllib3, requests, python-dateutil, github3.py, selenium, robotframework-seleniumlibrary, click, docutils, sarge, raven, unicodecsv, simple-salesforce, salesforce-bulk, humanfriendly, rst2ansi, MarkupSafe, coloredlogs, pytz, plaintable, jinja2, SQLAlchemy, future, cumulusci
      Found existing installation: jwcrypto 0.5.0
        Uninstalling jwcrypto-0.5.0:
          Successfully uninstalled jwcrypto-0.5.0
      Found existing installation: python-dateutil 2.7.3
        Uninstalling python-dateutil-2.7.3:
          Successfully uninstalled python-dateutil-2.7.3
      Found existing installation: cumulusci 2.0.7
        Uninstalling cumulusci-2.0.7:
          Successfully uninstalled cumulusci-2.0.7
    Successfully installed MarkupSafe-1.1.0 SQLAlchemy-1.2.14 asn1crypto-0.24.0 certifi-2018.11.29 cffi-1.11.5 chardet-3.0.4 click-7.0 coloredlogs-10.0 cryptography-2.4.2 cumulusci-2.2.3 docutils-0.14 future-0.17.1 github3.py-1.2.0 humanfriendly-4.17 idna-2.7 jinja2-2.10 jwcrypto-0.6.0 lxml-4.2.5 plaintable-0.1.1 pycparser-2.19 python-dateutil-2.7.5 pytz-2018.7 raven-6.9.0 requests-2.20.1 robotframework-3.0.4 robotframework-seleniumlibrary-3.2.0 rst2ansi-0.1.5 salesforce-bulk-2.1.0 sarge-0.1.5.post0 selenium-3.141.0 simple-salesforce-0.74.2 unicodecsv-0.14.1 uritemplate-3.0.0 urllib3-1.24.1 xmltodict-0.11.0

## Update homebrew formula<a id="sec-1-2"></a>

`homebrew-pypi-poet` is used to generate an updated formula:

```shell
poet --formula cumulusci
```


However, this doesn't update the description, `HEAD`, or test.

## Manually update generated format<a id="sec-1-3"></a>

```ruby
class Cumulusci < Formula
  include Language::Python::Virtualenv

  desc "Python framework for building portable automation for Salesforce projects"
  homepage "https://github.com/SFDO-Tooling/CumulusCI"
  url "https://files.pythonhosted.org/packages/4f/90/028caa2f5ed78a03ce7262e6817d94afbf6e25cd04452b10124f724bd5eb/cumulusci-2.2.3.tar.gz"
  sha256 "11f423edab27a45f2e8652006d74ceb28e4e6d5f81efd6c7e54f7d3e269d8254"
  head "https://github.com/SFDO-Tooling/CumulusCI.git"

# dependencies removed

  def install
    virtualenv_create(libexec, "python3")
    virtualenv_install_with_resources
  end

  test do
    system bin/"cci", "version"
  end
end
```