### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: objective-c
+os: osx
+osx_image: xcode10.1	
+before_install:
+  - brew update >/dev/null
+script:
+  - brew audit cumulusci.rb
+  - brew install -v cumulusci.rb
+  - brew test cumulusci.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ before_install:
   - brew update >/dev/null
 script:
   - brew audit cumulusci.rb
-  - brew install -v cumulusci.rb
+  - brew install cumulusci.rb
   - brew test cumulusci.rb

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Build Status](https://travis-ci.com/jstvz/homebrew-sfdo.svg?branch=master)](https://travis-ci.com/jstvz/homebrew-sfdo)
 
-----
-
 Homebrew tap for SFDO Developer Tools
 - [CumulusCI](https://github.com/SFDO-Tooling/CumulusCI)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # homebrew-sfdo
 
+[![Build Status](https://travis-ci.com/jstvz/homebrew-sfdo.svg?branch=master)](https://travis-ci.com/jstvz/homebrew-sfdo)
+
+----
+
 Homebrew tap for SFDO Developer Tools
 - [CumulusCI](https://github.com/SFDO-Tooling/CumulusCI)
 

--- a/cumulusci.rb
+++ b/cumulusci.rb
@@ -1,13 +1,13 @@
 class Cumulusci < Formula
   include Language::Python::Virtualenv
 
-  desc "Python framework for building portable automation for Salesforce projects"
-  head "https://github.com/SFDO-Tooling/CumulusCI.git"
+  desc "Python framework for building automation for Salesforce projects"
   homepage "https://github.com/SFDO-Tooling/CumulusCI"
   url "https://files.pythonhosted.org/packages/17/29/031a86a40c44d0e7d284ee2a99866a15331be233f54adad86d19a9b9cbf7/cumulusci-2.3.1.tar.gz"
   sha256 "47449e4f4473fe40ef5688118f76d79f577823bedd42ffad586116fb97e738d4"
+  head "https://github.com/SFDO-Tooling/CumulusCI.git"
 
-  depends_on "python3"
+  depends_on "python"
 
   resource "asn1crypto" do
     url "https://files.pythonhosted.org/packages/fc/f1/8db7daa71f414ddabfa056c4ef792e1461ff655c2ae2928a2b675bfed6b4/asn1crypto-0.24.0.tar.gz"


### PR DESCRIPTION
This PR adds continuous integration for our homebrew builds. I selected TravisCI because Circle charges for macOS builds. Also includes some reformatting of `cumulusci.rb` to pass `brew audit`.